### PR TITLE
Cambio de creacion del rango de fechas para obtener bitacoras

### DIFF
--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date
 import logging
 from fastapi import Response, status, HTTPException
 from typing import List, Optional, Sequence

--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -54,8 +54,6 @@ class PlantsService():
         if month:
             left = date(year, month, 1)
             right = date(year+1, 1, 1) if month == 12 else date(year, month+1, 1)
-            print(left)
-            print(right)
         else:
             left = date(year, 1, 1)
             right = date(year+1, 1, 1)

--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -53,7 +53,7 @@ class PlantsService():
     ) -> List[LogSchema]:
         if month:
             left = date(year, month, 1)
-            right = date(year+1, 1, 1) if month == 11 else date(year, month+1, 1)
+            right = date(year+1, 1, 1) if month == 12 else date(year, month+1, 1)
             print(left)
             print(right)
         else:

--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -53,7 +53,9 @@ class PlantsService():
     ) -> List[LogSchema]:
         if month:
             left = date(year, month, 1)
-            right = left + timedelta(weeks=4)
+            right = date(year+1, 1, 1) if month == 11 else date(year, month+1, 1)
+            print(left)
+            print(right)
         else:
             left = date(year, 1, 1)
             right = date(year+1, 1, 1)


### PR DESCRIPTION
## Describe your changes, marking the new features and possible risks
- Problema: A la hora de hacer un get de las bitacoras (con un mes definido), el range se generaba entre 1 y 29 del mes, dejando afuera las bitacoras que se pudiesen haber creado el 30 o 31 de algun mes.
- Solucion: se reimplemento la forma en la que se crea el range para manejar este caso.


