### PR TITLE
Fix endpoint delete & Refactor error handling

### DIFF
--- a/app/controller/Plants.py
+++ b/app/controller/Plants.py
@@ -78,7 +78,10 @@ class PlantController:
             content=jsonable_encoder(log)
         )
 
-    def handle_delete_photo(self,  response: Response, id_log: int, id_photo: int) -> JSONResponse:
+    def handle_delete_photo(self, 
+                            response: Response, 
+                            id_log: int, 
+                            id_photo: int) -> JSONResponse:
         try:
             self.plants_service.delete_photo(id_log, id_photo)
             return JSONResponse(

--- a/app/controller/Plants.py
+++ b/app/controller/Plants.py
@@ -78,9 +78,9 @@ class PlantController:
             content=jsonable_encoder(log)
         )
 
-    def handle_delete_photo(self, 
-                            response: Response, 
-                            id_log: int, 
+    def handle_delete_photo(self,
+                            response: Response,
+                            id_log: int,
                             id_photo: int) -> JSONResponse:
         try:
             self.plants_service.delete_photo(id_log, id_photo)

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,7 @@ from app.schemas.Log import (
     LogPartialUpdateSchema,
     LogPhotoCreateSchema,
 )
-from app.schemas.plant import (
-    PlantCreateSchema
-)
+from app.schemas.plant import PlantCreateSchema
 from app.service.Plants import PlantsService
 
 tags_metadata = [
@@ -53,13 +51,9 @@ async def shutdown_db_client():
     "/plants",
     tags=["Plants"],
     responses={
-        status.HTTP_200_OK: {
-            "description": "Return the plant successfully created."
-        },
+        status.HTTP_200_OK: {"description": "Return the plant successfully created."},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid request body"},
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {
-            "description": "Internal server error"
-        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Internal server error"},
     },
 )
 async def create_plant(item: PlantCreateSchema):
@@ -78,15 +72,11 @@ async def get_all_plants(id_user: int = Query(None), limit: int = Query(1024)):
     "/plants/{id_plant}",
     tags=["Plants"],
     responses={
-        status.HTTP_200_OK: {
-            "description": "Return the plant with the given ID."
-        },
+        status.HTTP_200_OK: {"description": "Return the plant with the given ID."},
         status.HTTP_404_NOT_FOUND: {
             "description": "The plant with the given ID was not found"
         },
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {
-            "description": "Internal server error"
-        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Internal server error"},
     },
 )
 async def get_one_plant(req: Request, id_plant: int):
@@ -105,9 +95,7 @@ async def get_one_plant(req: Request, id_plant: int):
         status.HTTP_204_NO_CONTENT: {
             "description": "Plant and DevicePlant relation was already deleted"
         },
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {
-            "description": "Internal server error"
-        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Internal server error"},
     },
 )
 async def delete_plant(response: Response, id_plant: int):
@@ -144,9 +132,7 @@ async def get_log(id_log: int):
     "/logs",
     tags=["Logs"],
 )
-async def create_log(
-    item: LogCreateSchema
-):
+async def create_log(item: LogCreateSchema):
     return plants_controller.handle_create_log(item)
 
 
@@ -154,9 +140,9 @@ async def create_log(
     "/logs/{id_log}",
     tags=["Logs"],
 )
-async def update_fields_in_log(id_log: str,
-                               log_update_set:
-                               LogPartialUpdateSchema = Body(...)):
+async def update_fields_in_log(
+    id_log: str, log_update_set: LogPartialUpdateSchema = Body(...)
+):
     return plants_controller.handle_update_log(id_log, log_update_set)
 
 
@@ -167,7 +153,7 @@ async def update_fields_in_log(id_log: str,
 async def get_logs_by_user(
     user_id: int,
     year: int = Query(..., gt=0),
-    month: Optional[int] = Query(None, ge=1, le=12)
+    month: Optional[int] = Query(None, ge=1, le=12),
 ):
     return plants_controller.handle_get_logs_by_user(user_id, year, month)
 
@@ -176,9 +162,7 @@ async def get_logs_by_user(
     "/logs/{id_log}/photos",
     tags=["Logs"],
 )
-async def add_photo(id_log: str,
-                    photo_create_set:
-                    LogPhotoCreateSchema = Body(...)):
+async def add_photo(id_log: str, photo_create_set: LogPhotoCreateSchema = Body(...)):
     return plants_controller.handle_add_photo(id_log, photo_create_set)
 
 
@@ -186,6 +170,5 @@ async def add_photo(id_log: str,
     "/logs/{id_log}/photos/{id_photo}",
     tags=["Logs"],
 )
-async def delete_photo(id_log: int,
-                       id_photo: int):
-    return plants_controller.handle_delete_photo(id_log, id_photo)
+async def delete_photo(response: Response, id_log: int, id_photo: int):
+    return plants_controller.handle_delete_photo(response, id_log, id_photo)

--- a/app/repository/Plants.py
+++ b/app/repository/Plants.py
@@ -12,6 +12,7 @@ from typing import Optional, Sequence
 from datetime import date
 
 from app.repository.PlantsRepository import PlantsRepository
+from app.utils.sql_exception_handling import withSQLExceptionsHandle
 
 load_dotenv()
 
@@ -38,17 +39,20 @@ class PlantsDB(PlantsRepository):
         self.session.execute(query)
         self.session.commit()
 
+    @withSQLExceptionsHandle()
     def get_plant_by_id(self, id_received: int) -> Plant:
         query = select(Plant).where(Plant.id == id_received)
         result = self.session.scalars(query).one()
         return result
 
+    @withSQLExceptionsHandle()
     def get_all_plants(self, limit: int) -> Sequence[Plant]:
         query = select(Plant).limit(limit)
         result = self.session.scalars(query).all()
         print(result)
         return result
 
+    @withSQLExceptionsHandle()
     def delete_plant(self, id_received: int) -> int:
         """
         Delete a plant by id and its logs
@@ -63,16 +67,19 @@ class PlantsDB(PlantsRepository):
         self.session.commit()
         return result.rowcount
 
+    @withSQLExceptionsHandle()
     def get_all_plants_by_user(
             self, id_user: int, limit: int) -> Sequence[Plant]:
         query = select(Plant).where(Plant.id_user == id_user).limit(limit)
         result = self.session.scalars(query).all()
         return result
 
+    @withSQLExceptionsHandle()
     def add(self, record: Base):
         self.session.add(record)
         self.session.commit()
 
+    @withSQLExceptionsHandle()
     def get_all_plant_types(self, limit: Optional[int]) -> Sequence[PlantType]:
         query = select(PlantType)
         if limit:
@@ -80,11 +87,13 @@ class PlantsDB(PlantsRepository):
         result = self.session.scalars(query).all()
         return result
 
+    @withSQLExceptionsHandle()
     def get_log(self, log_id: int) -> Log:
         query = select(Log).where(Log.id == log_id)
         result = self.session.scalars(query).one()
         return result
 
+    @withSQLExceptionsHandle()
     def get_logs_between(self,
                          user_id: int,
                          cleft: date,
@@ -96,6 +105,7 @@ class PlantsDB(PlantsRepository):
         result = self.session.scalars(query).all()
         return result
 
+    @withSQLExceptionsHandle()
     def get_plant_type_by_botanical_name(
             self, botanical_name_given: str) -> PlantType:
         query = select(PlantType).where(
@@ -103,6 +113,7 @@ class PlantsDB(PlantsRepository):
         result = self.session.scalars(query).one()
         return result
 
+    @withSQLExceptionsHandle()
     def update_log(self,
                    log_id: str,
                    title: Optional[str],
@@ -124,11 +135,13 @@ class PlantsDB(PlantsRepository):
         self.session.commit()
         return True
 
+    @withSQLExceptionsHandle()
     def find_by_log_id(self, log_id: str) -> Log:
         query = select(Log).where(Log.id == log_id)
         result = self.session.scalars(query).one()
         return result
 
+    @withSQLExceptionsHandle()
     def delete_photo_from_log(self, id_log: int, id_photo: int) -> int:
         query = delete(LogPhoto).where(
             LogPhoto.id == id_photo, LogPhoto.log_id == id_log

--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -17,9 +17,7 @@ from app.schemas.Log import (
 from app.schemas.plant import PlantCreateSchema, PlantSchema
 from app.schemas.plant_type import PlantTypeSchema
 from app.service.Measurements import MeasurementService
-from app.utils.sql_exception_handling import withSQLExceptionsHandle
 from app.service.Users import UserService
-from sqlalchemy.exc import SQLAlchemyError, NoResultFound
 
 logger = logging.getLogger("app")
 logger.setLevel("DEBUG")
@@ -44,17 +42,11 @@ class PlantsService():
             raise err
 
     def get_log(self, log_id: int) -> LogSchema:
-        try:
-            log: Log = self.plants_repository.get_log(log_id)
-            # TODO: Este print hace que los logs se parsen bien a LogSchemas.
-            # No quitar a menos que se encuentre una mejor solucion.
-            print(log)
-            return LogSchema.model_validate(log.__dict__)
-        except NoResultFound:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Could not found a log with id {log_id}"
-            )
+        log: Log = self.plants_repository.get_log(log_id)
+        # TODO: Este print hace que los logs se parsen bien a LogSchemas.
+        # No quitar a menos que se encuentre una mejor solucion.
+        print(log)
+        return LogSchema.model_validate(log.__dict__)
 
     def get_logs_by_user(
         self,

--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -30,7 +30,6 @@ class PlantsService():
     def __init__(self, plants_repository: PlantsRepository):
         self.plants_repository = plants_repository
 
-    @withSQLExceptionsHandle
     def create_log(self, input_log: LogCreateSchema) -> LogSchema:
         try:
             log = Log.from_pydantic(input_log)
@@ -44,7 +43,6 @@ class PlantsService():
             self.plants_repository.rollback()
             raise err
 
-    @withSQLExceptionsHandle
     def get_log(self, log_id: int) -> LogSchema:
         try:
             log: Log = self.plants_repository.get_log(log_id)
@@ -58,7 +56,6 @@ class PlantsService():
                 detail=f"Could not found a log with id {log_id}"
             )
 
-    @withSQLExceptionsHandle
     def get_logs_by_user(
         self,
         user_id: int,
@@ -83,7 +80,6 @@ class PlantsService():
             logs
         ))
 
-    @withSQLExceptionsHandle
     def update_log(
         self,
         log_id: str,
@@ -107,7 +103,6 @@ class PlantsService():
             self.plants_repository.rollback()
             raise err
 
-    @withSQLExceptionsHandle
     def add_photo(
         self,
         id_log: str,
@@ -126,7 +121,6 @@ class PlantsService():
             self.plants_repository.rollback()
             raise err
 
-    @withSQLExceptionsHandle
     def delete_photo(self, id_log: int, id_photo: int):
         try:
             result_rowcount = self.plants_repository.delete_photo_from_log(
@@ -139,17 +133,15 @@ class PlantsService():
                         f"{id_photo} in log with id {id_log}"
                     )
                 )
-        except SQLAlchemyError as err:
+        except Exception as err:
             self.plants_repository.rollback()
             raise err
 
-    @withSQLExceptionsHandle
     def get_plant_type(self, botanical_name: str) -> PlantTypeSchema:
         plant_type = self.plants_repository.\
             get_plant_type_by_botanical_name(botanical_name)
         return PlantTypeSchema.model_validate(plant_type.__dict__)
 
-    @withSQLExceptionsHandle
     def get_all_plant_types(
         self, limit: Optional[int]
     ) -> List[PlantTypeSchema]:
@@ -159,7 +151,6 @@ class PlantsService():
             plant_types
         ))
 
-    @withSQLExceptionsHandle
     async def create_plant(self, data: PlantCreateSchema) -> PlantSchema:
         await UserService.check_existing_user(data.id_user)
         try:
@@ -172,20 +163,17 @@ class PlantsService():
             self.plants_repository.rollback()
             raise err
 
-    @withSQLExceptionsHandle
     def get_plant(self, id_received: int) -> PlantSchema:
         return PlantSchema.model_validate(
             self.plants_repository.get_plant_by_id(id_received).__dict__
         )
 
-    @withSQLExceptionsHandle
     def get_all_plants(self, limit: int) -> List[PlantSchema]:
         return list(map(
             lambda pl: PlantSchema.model_validate(pl.__dict__),
             self.plants_repository.get_all_plants(limit)
         ))
 
-    @withSQLExceptionsHandle
     def get_plants_by_user(
         self, id_user: int, limit: int
     ) -> List[PlantSchema]:
@@ -201,7 +189,7 @@ class PlantsService():
                 raise RowNotFoundError(
                     f"Could not found plant with id {id_plant}"
                 )
-        except SQLAlchemyError as err:
+        except Exception as err:
             self.plants_repository.rollback()
             raise err
 

--- a/app/utils/sql_exception_handling.py
+++ b/app/utils/sql_exception_handling.py
@@ -36,7 +36,7 @@ def handle_common_errors(err):
 
     if isinstance(err, NoResultFound):
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=format(err)
+            status_code=status.HTTP_404_NOT_FOUND, detail=format(err)
         )
 
     logger.error(format(err))


### PR DESCRIPTION
## Describe your changes, marking the new features and possible risks

Mientras probaba el gateway, el endpoint delete de plant me tiraba error... así que:

- Arreglo endpoint delete: no handleaba la excepción `RowNotFoundError` del repositorio. Ahora retorna 204 si la planta ya estaba borrada desde antes (y para ser consistentes, manejé el mismo comportamiento para el caso de borrar una foto de una bitácora; si no existia foto e intento borrar de nuevo: se disparará 204)
- Cambio de lugar los `withSQLExceptionsHandle`. La capa de repositorio ahora es la única que conoce a SQL.

