### PR TITLE
Remove anticipated return

### DIFF
--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -96,8 +96,7 @@ class PlantsService():
                 log_update_set.content,
                 log_update_set.plant_id
             )
-            if not result:
-                return None
+
             log = self.plants_repository.find_by_log_id(log_id)
             # TODO: Este print hace que los logs se parsen bien a LogSchemas.
             # No quitar a menos que se encuentre una mejor solucion.

--- a/app/service/Plants.py
+++ b/app/service/Plants.py
@@ -90,7 +90,7 @@ class PlantsService():
         log_update_set: LogPartialUpdateSchema
     ) -> Optional[LogSchema]:
         try:
-            result = self.plants_repository.update_log(
+            self.plants_repository.update_log(
                 log_id,
                 log_update_set.title,
                 log_update_set.content,


### PR DESCRIPTION
## Describe your changes, marking the new features and possible risks
- Cuando se actualizaba un log y el update set estaba vacio, el repositorio retornaba False (indicando que no se actualizo nada). Ante esto, el servicio retornaba None, indicado que nada se habia actualizado. Ante esto, el controller no detectaba un Log, entonces tiraba 404 c:
- Se removio el return None del servicio.
